### PR TITLE
fix(deploy-to-was-ecs): can't delete target group

### DIFF
--- a/deploy-to-aws-ecs/components/ecs-service/alb.tf
+++ b/deploy-to-aws-ecs/components/ecs-service/alb.tf
@@ -52,7 +52,7 @@ module "ingress" {
 
   target_groups = {
     api = {
-      name              = "api"
+      name_prefix       = "api-"
       protocol          = "HTTP"
       port              = 8080
       target_type       = "ip"


### PR DESCRIPTION
Looks like the TF has issues deleting the old target group. Using name_prefix for now to get around this.