### PR TITLE
fix(deploy-to-aws-ecs): set port to 5000

### DIFF
--- a/deploy-to-aws-ecs/components/ecs-service/alb.tf
+++ b/deploy-to-aws-ecs/components/ecs-service/alb.tf
@@ -54,7 +54,7 @@ module "ingress" {
     api = {
       name_prefix       = "api-"
       protocol          = "HTTP"
-      port              = 8080
+      port              = 5000
       target_type       = "ip"
       create_attachment = false
       health_check = {

--- a/deploy-to-aws-ecs/components/ecs-service/service.tf
+++ b/deploy-to-aws-ecs/components/ecs-service/service.tf
@@ -16,15 +16,15 @@ module "service" {
       port_mappings = [
         {
           name          = "http"
-          containerPort = 8080
-          hostPort      = 8080
+          containerPort = 5000
+          hostPort      = 5000
           protocol      = "http"
         }
       ]
       memory_reservation = 100
       environment        = []
       health_check = {
-        command = ["CMD-SHELL", "curl -f localhost:8080/livez || exit 1"]
+        command = ["CMD-SHELL", "curl -f localhost:5000/livez || exit 1"]
       }
     }
   }
@@ -33,7 +33,7 @@ module "service" {
     service = {
       target_group_arn = module.ingress.target_groups["api"].arn
       container_name   = "api"
-      container_port   = 8080
+      container_port   = 5000
     }
   }
 
@@ -42,7 +42,7 @@ module "service" {
     ingress_http = {
       type                     = "ingress"
       from_port                = 0
-      to_port                  = 8080
+      to_port                  = 5000
       protocol                 = "tcp"
       description              = "Service port"
       source_security_group_id = module.ingress.security_group_id


### PR DESCRIPTION
Somewhere, the PORT env var is being set to 5000, overriding the default value of 8080.