### PR TITLE
fix(deploy-to-aws-ecs): wrong hosted zone?

### DIFF
--- a/deploy-to-aws-ecs/components/ecs-service/route53_record.tf
+++ b/deploy-to-aws-ecs/components/ecs-service/route53_record.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "cname" {
-  zone_id = module.ingress.zone_id
+  zone_id = var.zone_id
   name    = var.domain_name
   type    = "CNAME"
   ttl     = 300


### PR DESCRIPTION
Getting a zone_id from the alb output that doesn't exist. Not sure why. Switching to the var.